### PR TITLE
Add an option to show single or multiple images in their own lightbox

### DIFF
--- a/js/photoswipe.js
+++ b/js/photoswipe.js
@@ -12,9 +12,15 @@ jQuery(function($) {
     });
 
     var parseThumbnailElements = function(el) {
-        var elements = $('body').find('a[data-width]:has(img)'),
+        var elements,
             galleryItems = [],
             index;
+        
+        if (galid = el.getAttribute('data-galid')){
+            elements = $('body').find('a[data-width][data-galid='+galid+']:has(img)');
+        } else {
+            elements = $('body').find('a[data-width]:has(img)');
+        }        
 
         elements.each(function(i) {
             var $el = $(this);


### PR DESCRIPTION
Add an option to show single or multiple images in their own lightbox by adding an additional attribute 'data-galid' to the link of the image.